### PR TITLE
Disable HTML rendering in markdown and show raw text for user messages

### DIFF
--- a/src/webview/App.css
+++ b/src/webview/App.css
@@ -1114,6 +1114,13 @@ body.vscode-high-contrast {
   line-height: 1.6;
 }
 
+.user-message-text {
+  margin: 0;
+  font-family: inherit;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 .message-text > *:first-child {
   margin-top: 0;
 }

--- a/src/webview/components/MessageItem.tsx
+++ b/src/webview/components/MessageItem.tsx
@@ -22,9 +22,16 @@ export function MessageItem(props: MessageItemProps) {
           when={hasParts()} 
           fallback={
             <Show when={props.message.text}>
-              <Streamdown mode={props.isStreaming ? "streaming" : "static"} class="message-text">
-                {props.message.text!}
-              </Streamdown>
+              <Show 
+                when={props.message.type === "user"}
+                fallback={
+                  <Streamdown mode={props.isStreaming ? "streaming" : "static"} class="message-text">
+                    {props.message.text!}
+                  </Streamdown>
+                }
+              >
+                <pre class="message-text user-message-text">{props.message.text}</pre>
+              </Show>
             </Show>
           }
         >

--- a/src/webview/lib/streamdown/markdown.tsx
+++ b/src/webview/lib/streamdown/markdown.tsx
@@ -5,7 +5,7 @@ import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import type { Options as RemarkRehypeOptions } from "remark-rehype";
 import remarkRehype from "remark-rehype";
-import rehypeRaw from "rehype-raw";
+
 import type { PluggableList } from "unified";
 import { unified } from "unified";
 import { hastToSolid, type Components, type HastNode } from "./hast-to-solid";
@@ -21,7 +21,7 @@ export type MarkdownOptions = {
 };
 
 const EMPTY_PLUGINS: PluggableList = [];
-const DEFAULT_REMARK_REHYPE_OPTIONS = { allowDangerousHtml: true };
+const DEFAULT_REMARK_REHYPE_OPTIONS = { allowDangerousHtml: false };
 
 // Plugin name cache for faster serialization
 const pluginNameCache = new WeakMap<Function, string>();
@@ -130,7 +130,6 @@ const createProcessor = (options: Readonly<MarkdownOptions>) => {
     .use(remarkGfm)
     .use(remarkPlugins)
     .use(remarkRehype, remarkRehypeOptions)
-    .use(rehypeRaw)
     .use(rehypePlugins);
 };
 


### PR DESCRIPTION
## Changes

- **Disable HTML in markdown**: Removed `rehype-raw` plugin and set `allowDangerousHtml: false` to prevent raw HTML from being rendered in assistant messages
- **User messages as plain text**: User messages now display as unformatted text using `pre-wrap` instead of being parsed as markdown
- **Bundle size reduction**: Removing rehype-raw reduced the App bundle from ~404KB to ~226KB

## Why

User messages should show exactly what was typed, not formatted as markdown. Additionally, rendering raw HTML in markdown could be a security concern and is unnecessary for this use case.