### PR TITLE
Improve session switcher filtering and sorting

### DIFF
--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -73,6 +73,7 @@ export const SessionSchema = z.object({
   title: z.string(),
   projectID: z.string(),
   directory: z.string(),
+  parentID: z.string().optional(),
   time: z.object({
     created: z.number(),
     updated: z.number(),

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -114,7 +114,22 @@ function App() {
   };
 
   const sessionsToShow = createMemo(() => {
-    return sessions().filter(s => s.id !== currentSessionId() || currentSessionId() !== null);
+    const root = sdkWorkspaceRoot();
+    const currentId = currentSessionId();
+    
+    return sessions()
+      .filter(s => {
+        // Only list sessions with primary agents (no parentID)
+        if (s.parentID) return false;
+        
+        // Filter to sessions in the same repo/worktree
+        if (root && s.directory !== root) return false;
+        
+        // Filter out the current session from the switcher list
+        return s.id !== currentId;
+      })
+      // Sort by edited time (updated) instead of started time (created)
+      .sort((a, b) => b.time.updated - a.time.updated);
   });
 
   // Helper: check if title is default timestamp-based

--- a/src/webview/components/SessionSwitcher.tsx
+++ b/src/webview/components/SessionSwitcher.tsx
@@ -56,7 +56,7 @@ export function SessionSwitcher(props: SessionSwitcherProps) {
               >
                 <div class="session-item-title">{session.title}</div>
                 <div class="session-item-time">
-                  {formatRelativeTime(session.time.created)}
+                  {formatRelativeTime(session.time.updated)}
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary

Improves the session switcher to show more relevant sessions:

- **Filter out child sessions**: Only displays sessions with primary agents (no parentID)
- **Filter by repo/worktree**: Only shows sessions from the current workspace directory
- **Sort by last edited**: Sessions are now sorted by last edited time instead of created time

## Changes

- Added `parentID` field to `SessionSchema` to identify child sessions
- Updated `sessionsToShow` memo in `App.tsx` with comprehensive filtering logic
- Changed `SessionSwitcher` to display `time.updated` instead of `time.created`